### PR TITLE
Make doc buffer `nomodifiable`.

### DIFF
--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -407,7 +407,7 @@ def get_doc_buffer(level=0, word=None):
     b = vim.current.buffer
     b[:] = None
     b[:] = doc
-    vim.command('setlocal nomodified bufhidden=wipe')
+    vim.command('setlocal nomodified bufhidden=wipe nomodifiable readonly nospell')
     #vim.command('setlocal previewwindow nomodifiable nomodified ro')
     #vim.command('set previewheight=%d'%len(b))# go to previous window
     vim.command('resize %d'%len(b))


### PR DESCRIPTION
I prefere to have the documentation buffer as `nomodifiable` to avoid accidentally entering insert mode. I also have some vim settings depending on the value weather the buffer is `modifiable`.
Or are there any reasons not to do this?
I would also prefer to explicitly set `nospell` as I sometimes have `spell` to avoid errors in the comments.