### PR TITLE
accept stdin requests and add method to reply to them

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -238,6 +238,8 @@ command! -nargs=0 IPythonXSelection :Python2or3 km_from_string(vim.eval('@*'))
 command! -nargs=* IPythonNew :Python2or3 new_ipy("<args>")
 command! -nargs=* IPythonInterrupt :Python2or3 interrupt_kernel_hack("<args>")
 command! -nargs=0 IPythonTerminate :Python2or3 terminate_kernel_hack()
+command! -nargs=0 -bang IPythonInput :Python2or3 InputPrompt(force='<bang>')
+command! -nargs=0 -bang IPythonInputSecret :Python2or3 InputPrompt(force='<bang>', hide_input=True)
 
 function! IPythonBalloonExpr()
 Python2or3 << endpython

--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -608,8 +608,7 @@ def update_subchannel_msgs(debug=False, force=False):
             current_stdin_prompt['is_password'] = m['content']['password']
             current_stdin_prompt['parent_msg_id'] = m['parent_header']['msg_id']
             s += m['content']['prompt']
-            vim.command('autocmd InsertEnter <buffer> :py EnteredInsertMode()')
-            echo('Awaiting input. call :IPythonInput or edit last vim-ipython line')
+            echo('Awaiting input. call :IPythonInput to reply')
 
         if s.find('\n') == -1:
             # somewhat ugly unicode workaround from
@@ -1034,10 +1033,3 @@ def get_session_history(session=None, pattern=None):
         return []
     except KeyError:
         return []
-
-def EnteredInsertMode():
-    if current_stdin_prompt and vim.eval('line(".")')==vim.eval('line("$")'):
-        if InputPrompt():
-            vim.command('autocmd InsertLeave <buffer> :normal! G$')
-            vim.command('autocmd InsertLeave <buffer> :autocmd! InsertLeave <buffer>')
-            vim.command('call feedkeys("\\<Esc>", "n")')


### PR DESCRIPTION
This pull request is for adding the option to reply to stdin requests from the kernel.
With this, it's possible to prompt for users, passwords or even use ipdb to debug a program.

Everytime the kernel asks for input, it will inform of that in the status line and it's possible to answer by going to the vim-ipython buffer and editing the last line, which will show the prompt text. I'm using vim input or inputsecret functions to ask for user input as I think that's more appropiate than just writing text in the buffer